### PR TITLE
DateTimePicker with timezone option

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -39,7 +39,7 @@
         // AMD is used - Register as an anonymous module.
         define(['jquery', 'moment'], factory);
     } else if (typeof exports === 'object') {
-        factory(require('jquery'), require('moment'));
+        factory(require('jquery'), require('moment'), require('moment-timezone'));
     } else {
         // Neither AMD nor CommonJS used. Use global variables.
         if (typeof jQuery === 'undefined') {
@@ -58,7 +58,7 @@
 
     var dateTimePicker = function (element, options) {
         var picker = {},
-            date = moment().startOf('d'),
+            date = moment().tz(options.timeZone).startOf('d'),
             viewDate = date.clone(),
             unset = true,
             input,
@@ -693,7 +693,7 @@
                     if (!isValid(currentDate, 'd')) {
                         clsName += ' disabled';
                     }
-                    if (currentDate.isSame(moment(), 'd')) {
+                    if (currentDate.isSame(moment().tz(options.timeZone), 'd')) {
                         clsName += ' today';
                     }
                     if (currentDate.day() === 0 || currentDate.day() === 6) {
@@ -1099,8 +1099,8 @@
                 clear: clear,
 
                 today: function () {
-                    if (isValid(moment(), 'd')) {
-                        setValue(moment());
+                    if (isValid(moment().tz(options.timeZone), 'd')) {
+                        setValue(moment().tz(options.timeZone));
                     }
                 },
 
@@ -1142,7 +1142,7 @@
                 if (input.val() !== undefined && input.val().trim().length !== 0) {
                     setValue(parseInputDate(input.val().trim()));
                 } else if (options.useCurrent && unset && ((input.is('input') && input.val().trim().length === 0) || options.inline)) {
-                    currentMoment = moment();
+                    currentMoment = moment().tz(options.timeZone);
                     if (typeof options.useCurrent === 'string') {
                         currentMoment = useCurrentGranularity[options.useCurrent](currentMoment);
                     }
@@ -1186,15 +1186,20 @@
                 return (widget ? hide() : show());
             },
 
-            parseInputDate = function (inputDate) {
-                if (options.parseInputDate === undefined) {
-                    if (moment.isMoment(inputDate) || inputDate instanceof Date) {
-                        inputDate = moment(inputDate);
-                    } else {
-                        inputDate = moment(inputDate, parseFormats, options.useStrict);
-                    }
+             parseInputDate = function (inputDate) {
+                var currentZoneOffset = moment().tz(options.timeZone).zone();
+                var incomingZoneOffset = moment(inputDate).zone();
+                
+                if (moment.isMoment(inputDate) || inputDate instanceof Date) {
+                    inputDate = moment(inputDate);
                 } else {
-                    inputDate = options.parseInputDate(inputDate);
+                    inputDate = moment(inputDate, parseFormats, options.useStrict);
+                }
+
+                if (incomingZoneOffset != currentZoneOffset) {
+                    var timeZoneIndicator = moment().tz(options.timeZone).format('Z');
+                    var dateWithTimeZoneInfo = moment(inputDate).format("YYYY-MM-DD[T]HH:mm:ss") + timeZoneIndicator;
+                    inputDate = moment(dateWithTimeZoneInfo).tz(options.timeZone);
                 }
                 inputDate.locale(options.locale);
                 return inputDate;
@@ -1477,6 +1482,16 @@
             return picker;
         };
 
+		picker.timeZone = function (newFormat) {
+            if (arguments.length === 0) {
+                return options.format;
+            }
+
+            options.timeZone = newFormat;
+            
+            return picker;
+        };
+		
         picker.dayViewHeaderFormat = function (newFormat) {
             if (arguments.length === 0) {
                 return options.dayViewHeaderFormat;
@@ -1613,7 +1628,7 @@
 
             if (typeof maxDate === 'string') {
                 if (maxDate === 'now' || maxDate === 'moment') {
-                    maxDate = moment();
+                    maxDate = moment().tz(options.timeZone);
                 }
             }
 
@@ -1649,7 +1664,7 @@
 
             if (typeof minDate === 'string') {
                 if (minDate === 'now' || minDate === 'moment') {
-                    minDate = moment();
+                    minDate = moment().tz(options.timeZone);
                 }
             }
 
@@ -1691,7 +1706,7 @@
 
             if (typeof defaultDate === 'string') {
                 if (defaultDate === 'now' || defaultDate === 'moment') {
-                    defaultDate = moment();
+                    defaultDate = moment().tz(options.timeZone);
                 }
             }
 
@@ -2335,7 +2350,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(options.timeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(7, 'd'));
                 } else {
@@ -2347,7 +2362,7 @@
                     this.show();
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(options.timeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(7, 'd'));
                 } else {
@@ -2358,7 +2373,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(options.timeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'y'));
                 } else {
@@ -2369,7 +2384,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(options.timeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'y'));
                 } else {
@@ -2380,7 +2395,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(options.timeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'd'));
                 }
@@ -2389,7 +2404,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(options.timeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'd'));
                 }
@@ -2398,7 +2413,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(options.timeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'M'));
                 }
@@ -2407,7 +2422,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(options.timeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'M'));
                 }
@@ -2428,7 +2443,7 @@
                 }
             },
             t: function () {
-                this.date(moment());
+                this.date(moment().tz(options.timeZone));
             },
             'delete': function () {
                 this.clear();


### PR DESCRIPTION
Calendar works in the timezone set from options. Internally uses moment timezone.
Moment-time zone-all-years.js Is used for time zone conversion:
http://momentjs.com/downloads/moment-timezone-with-data-2010-2020.js

Example:
dateControl.datetimepicker({
timeZone: 'Asia/Kolkata'
});
